### PR TITLE
Fix VideoPlayer constantly reloading

### DIFF
--- a/app/components/VideoPlayer.jsx
+++ b/app/components/VideoPlayer.jsx
@@ -41,6 +41,14 @@ class VideoPlayer extends React.Component {
         this.state = { playing: false };
     }
 
+    shouldComponentUpdate(nextProps, nextState) {
+        if (nextState.playing != this.state.playing) {
+            return true;
+        }
+
+        return false;
+    }
+
     getImageDimensions({ target: img }) {
         this.setState({
             imageHeight: img.offsetHeight,

--- a/app/components/VideoPlayer.jsx
+++ b/app/components/VideoPlayer.jsx
@@ -42,7 +42,14 @@ class VideoPlayer extends React.Component {
     }
 
     shouldComponentUpdate(nextProps, nextState) {
-        if (nextState.playing != this.state.playing) {
+        if (nextState.playing != this.state.playing ||
+            nextState.imageHeight != this.state.imageHeight ||
+            nextState.imageWidth != this.state.imageWidth ||
+            nextProps.autoplay != this.props.autoplay ||
+            nextProps.showControls != this.props.showControls ||
+            nextProps.showVideoDetails != this.props.showVideoDetails ||
+            nextProps.videoUrl != this.props.videoUrl ||
+            nextProps.placeholderImage != this.props.placeholderImage) {
             return true;
         }
 


### PR DESCRIPTION
Fixes #83 .

### PR Description
Uses shouldComponentUpdate to prevent VideoPlayer from reloading itself for no reason
