### PR TITLE
Fix Blackout Page Overflow

### DIFF
--- a/app/pages/blackout/index.jsx
+++ b/app/pages/blackout/index.jsx
@@ -18,6 +18,7 @@ const Page = styled.div`
     width: 100%;
     height: 100%;
     color: #F1F7FF;
+    overflowX: hidden;
 `;
 
 /* Styled elements */


### PR DESCRIPTION
Fixes #136 .

### PR Description
Prevented overflow on blackout page specifically so we can keep partial images 'cause they look dank
