### PR TITLE
Use node v11 rather than latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- stable
+- "11"
 script: yarn run test
 notifications:
   slack:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:11
 
 MAINTAINER MHacks Team
 


### PR DESCRIPTION
### PR Description
Using `node:latest`, which was recently updated to Node v12, breaks multiple dependencies within the build process, such as `native-metrics` and `bcrypt_lib`. This PR hardcodes a dependency on Node v11, which seems to be the most recent version that builds successfully.

### What needs to be reviewed?
I imagine the CI will make sure that the build runs, so that's probably about it