### PR TITLE
Fix leaking of internal Mongoose properties

### DIFF
--- a/server/routes/api/user.js
+++ b/server/routes/api/user.js
@@ -313,7 +313,7 @@ router.post('/ticket/verify', authMiddleware('scanner admin', 'api'), function(
                                                                                             status: true,
                                                                                             scanevent: Object.assign(
                                                                                                 {},
-                                                                                                scanevent,
+                                                                                                scanevent.toJSON(),
                                                                                                 {
                                                                                                     user: profile
                                                                                                 }


### PR DESCRIPTION
### PR Description

Since we're using `Object.assign` here the scan event's `.toJSON()`, which removes internal Mongoose properties, isn't called, and the properties end up making it into the API response. These properties (like `_$` and `_doc` include things like active and old tokens as well as password hashes. This PR simply manually calls `.toJSON()`, like (from what I can tell) every other place in the back-end that uses `Object.assign` in this manner; this removes those internal properties.