### PR TITLE
Fix Landing Page Date Suffixes

### DIFF
--- a/app/pages/home/apply.jsx
+++ b/app/pages/home/apply.jsx
@@ -77,14 +77,14 @@ class Apply extends React.Component {
                                 day: 'numeric',
                                 timeZone: 'America/Detroit'
                             })}
-                            st–
+                            th–
                             {new Date(
                                 this.props.configurationState.data.end_date
                             ).toLocaleString('default', {
                                 day: 'numeric',
                                 timeZone: 'America/Detroit'
                             })}
-                            rd. Anywhere you are.
+                            th. Anywhere you are.
                         </ApplyBoxText>
                         <ApplyBoxText>
                             {is_application_open


### PR DESCRIPTION
A quick fix to the landing page dates. They used to read "October 15st - 17rd", this commit updates them to "Oct 15th - 17th".
